### PR TITLE
Modification to work with Hexo3

### DIFF
--- a/src/Command.coffee
+++ b/src/Command.coffee
@@ -9,8 +9,8 @@ path = require 'path'
 log = new Log()
 
 # Hexo
-file = hexo.file
-themeDir = hexo.theme_dir
+file = require 'hexo-fs'
+themeDir = hexo.theme_dir # hexo is undefined here. I just hard-coded to pass here. You should modify here properly.
 layoutDir = path.resolve themeDir, "layout"
 assetDir = path.resolve __dirname, "../asset"
 mathJaxLayoutName = "math-jax.ejs"

--- a/src/Layout.coffee
+++ b/src/Layout.coffee
@@ -1,6 +1,6 @@
-extend = hexo.extend
-util = hexo.util
-file = hexo.file
+# extend = hexo.extend
+util = require 'hexo-util'
+file = require 'hexo-fs'
 
 async = require 'async'
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,7 +1,7 @@
 # Hexo
 extend = hexo.extend
-util = hexo.util
-file = hexo.file
+util = require 'hexo-util'
+file = require 'hexo-fs'
 htmlTag = hexo.util.html_tag
 
 # Modules


### PR DESCRIPTION
Current hexo-math doesn't work with Hexo3. I modified some part to use correct module (newly introduced in Hexo 3). I couldn't correct `themeDir` in Command.js. I just hard coded this part to avoid error. I hope you merge this pull request and correct the `themeDir` in Command.js that hexo-math would work well with Hexo3.