### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ In `.test-site/source/_post` folder, add a pair of file for each test cases:
 
 The `.md` file contains the Markdown source of a post and the `.expected` file contains expected HTML rendered from the source.
 
-If a test case is added to address certian issues, the issue id should be added to the `.md`'s front matter section:
+If a test case is added to address certain issues, the issue id should be added to the `.md`'s front matter section:
 
 ```markdown
 title: "Tag Escpae"


### PR DESCRIPTION
@akfish, I've corrected a typographical error in the documentation of the [hexo-math](https://github.com/akfish/hexo-math) project. Specifically, I've changed certian to certain. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.